### PR TITLE
Update runners and two recipes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     needs: changed_recipes
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-14', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2025']
+        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2025-vs2026']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set git to use LF

--- a/profiles/macos-14
+++ b/profiles/macos-14
@@ -1,8 +1,0 @@
-[settings]
-arch=armv8
-build_type=Release
-compiler=apple-clang
-compiler.cppstd=gnu17
-compiler.libcxx=libc++
-compiler.version=15
-os=Macos

--- a/profiles/windows-2025-vs2026
+++ b/profiles/windows-2025-vs2026
@@ -4,5 +4,5 @@ build_type=Release
 compiler=msvc
 compiler.cppstd=14
 compiler.runtime=dynamic
-compiler.version=194
+compiler.version=195
 os=Windows

--- a/recipes/boost/conanfile.py
+++ b/recipes/boost/conanfile.py
@@ -89,7 +89,7 @@ CONFIGURE_OPTIONS = (
 
 class BoostConan(ConanFile):
     name = "boost"
-    version = "tci-1.90.0"
+    version = "tci-1.91.0"
     description = "Boost provides free peer-reviewed portable C++ source libraries"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://www.boost.org"
@@ -775,7 +775,7 @@ class BoostConan(ConanFile):
             if Version(self.version) == "1.86.0" and is_msvc(self):
                 setattr(self.options, "without_process", True)
 
-        if Version(self.version) == "1.90.0":
+        if Version(self.version) in ["1.90.0", "1.91.0"]:
             # FIXME: boost.coroutine doesn't support Windows ARM64 due to missing context assembly
             # See https://github.com/boostorg/context/issues/296
             if self._is_windows_platform and "arm" in str(self.settings.arch):
@@ -816,6 +816,14 @@ class BoostConan(ConanFile):
                 and not self.options.without_stacktrace
                 and self.settings.os != "Windows"
             )
+        elif Version(self.version) >= "1.91.0":
+            # INFO: from_exception is built for all targets; only Cygwin is excluded upstream
+            # https://github.com/boostorg/stacktrace/blob/boost-1.91.0/build/Jamfile.v2#L252
+            if self.options.header_only or self.options.without_stacktrace:
+                return False
+            if self.settings.get_safe("os.subsystem") == "cygwin":
+                return False
+            return True
         elif Version(self.version) >= "1.86.0":
             # https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L148
             return (
@@ -1140,7 +1148,7 @@ class BoostConan(ConanFile):
     def source(self):
         get(
             self,
-            f"https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.bz2",
+            f"https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2",
             destination=self.source_folder,
             strip_root=True,
         )

--- a/recipes/boost/conanfile.py
+++ b/recipes/boost/conanfile.py
@@ -44,7 +44,7 @@ import shutil
 import sys
 import yaml
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2.5"
 
 # When adding (or removing) an option, also add this option to the list in
 # `rebuild-dependencies.yml` and re-run that script.

--- a/recipes/boost/dependencies/dependencies-tci-1.91.0.yml
+++ b/recipes/boost/dependencies/dependencies-tci-1.91.0.yml
@@ -1,0 +1,293 @@
+configure_options:
+- atomic
+- charconv
+- chrono
+- cobalt
+- container
+- context
+- contract
+- coroutine
+- date_time
+- exception
+- fiber
+- filesystem
+- graph
+- graph_parallel
+- iostreams
+- json
+- locale
+- log
+- math
+- mpi
+- nowide
+- process
+- program_options
+- python
+- random
+- regex
+- serialization
+- stacktrace
+- test
+- thread
+- timer
+- type_erasure
+- url
+- wave
+dependencies:
+  atomic: []
+  charconv: []
+  chrono: []
+  cobalt:
+  - container
+  - context
+  cobalt_io:
+  - cobalt
+  cobalt_io_ssl:
+  - cobalt
+  container: []
+  context: []
+  contract:
+  - exception
+  - thread
+  coroutine:
+  - context
+  - exception
+  date_time: []
+  exception: []
+  fiber:
+  - context
+  - filesystem
+  fiber_numa:
+  - fiber
+  filesystem:
+  - atomic
+  graph:
+  - math
+  - random
+  - regex
+  - serialization
+  graph_parallel:
+  - filesystem
+  - graph
+  - mpi
+  - random
+  - serialization
+  iostreams:
+  - random
+  - regex
+  json:
+  - container
+  locale:
+  - charconv
+  - thread
+  log:
+  - atomic
+  - date_time
+  - exception
+  - filesystem
+  - regex
+  - thread
+  log_setup:
+  - log
+  math: []
+  math_c99:
+  - math
+  math_c99f:
+  - math
+  math_c99l:
+  - math
+  math_tr1:
+  - math
+  math_tr1f:
+  - math
+  math_tr1l:
+  - math
+  mpi:
+  - graph
+  - serialization
+  mpi_python:
+  - mpi
+  - python
+  nowide:
+  - filesystem
+  numpy:
+  - python
+  prg_exec_monitor:
+  - test
+  process:
+  - context
+  - filesystem
+  program_options: []
+  python: []
+  random: []
+  regex: []
+  serialization: []
+  stacktrace: []
+  stacktrace_addr2line:
+  - stacktrace
+  stacktrace_backtrace:
+  - stacktrace
+  stacktrace_basic:
+  - stacktrace
+  stacktrace_from_exception:
+  - stacktrace
+  stacktrace_noop:
+  - stacktrace
+  stacktrace_windbg:
+  - stacktrace
+  stacktrace_windbg_cached:
+  - stacktrace
+  test:
+  - exception
+  test_exec_monitor:
+  - test
+  thread:
+  - atomic
+  - chrono
+  - container
+  - date_time
+  - exception
+  timer: []
+  type_erasure:
+  - thread
+  unit_test_framework:
+  - prg_exec_monitor
+  - test
+  - test_exec_monitor
+  url: []
+  wave:
+  - filesystem
+  - serialization
+  wserialization:
+  - serialization
+libs:
+  atomic:
+  - boost_atomic
+  charconv:
+  - boost_charconv
+  chrono:
+  - boost_chrono
+  cobalt:
+  - boost_cobalt
+  cobalt_io:
+  - boost_cobalt_io
+  cobalt_io_ssl:
+  - boost_cobalt_io_ssl
+  container:
+  - boost_container
+  context:
+  - boost_context
+  contract:
+  - boost_contract
+  coroutine:
+  - boost_coroutine
+  date_time:
+  - boost_date_time
+  exception:
+  - boost_exception
+  fiber:
+  - boost_fiber
+  fiber_numa:
+  - boost_fiber_numa
+  filesystem:
+  - boost_filesystem
+  graph:
+  - boost_graph
+  graph_parallel:
+  - boost_graph_parallel
+  iostreams:
+  - boost_iostreams
+  json:
+  - boost_json
+  locale:
+  - boost_locale
+  log:
+  - boost_log
+  log_setup:
+  - boost_log_setup
+  math: []
+  math_c99:
+  - boost_math_c99
+  math_c99f:
+  - boost_math_c99f
+  math_c99l:
+  - boost_math_c99l
+  math_tr1:
+  - boost_math_tr1
+  math_tr1f:
+  - boost_math_tr1f
+  math_tr1l:
+  - boost_math_tr1l
+  mpi:
+  - boost_mpi
+  mpi_python:
+  - boost_mpi_python
+  nowide:
+  - boost_nowide
+  numpy:
+  - boost_numpy{py_major}{py_minor}
+  prg_exec_monitor:
+  - boost_prg_exec_monitor
+  process:
+  - boost_process
+  program_options:
+  - boost_program_options
+  python:
+  - boost_python{py_major}{py_minor}
+  random:
+  - boost_random
+  regex:
+  - boost_regex
+  serialization:
+  - boost_serialization
+  stacktrace: []
+  stacktrace_addr2line:
+  - boost_stacktrace_addr2line
+  stacktrace_backtrace:
+  - boost_stacktrace_backtrace
+  stacktrace_basic:
+  - boost_stacktrace_basic
+  stacktrace_from_exception:
+  - boost_stacktrace_from_exception
+  stacktrace_noop:
+  - boost_stacktrace_noop
+  stacktrace_windbg:
+  - boost_stacktrace_windbg
+  stacktrace_windbg_cached:
+  - boost_stacktrace_windbg_cached
+  test: []
+  test_exec_monitor:
+  - boost_test_exec_monitor
+  thread:
+  - boost_thread
+  timer:
+  - boost_timer
+  type_erasure:
+  - boost_type_erasure
+  unit_test_framework:
+  - boost_unit_test_framework
+  url:
+  - boost_url
+  wave:
+  - boost_wave
+  wserialization:
+  - boost_wserialization
+requirements:
+  iostreams:
+  - bzip2
+  - lzma
+  - zlib
+  - zstd
+  locale:
+  - iconv
+  - icu
+  python:
+  - python
+  regex:
+  - icu
+  stacktrace:
+  - backtrace
+static_only:
+- boost_exception
+- boost_test_exec_monitor
+version: 1.91.0

--- a/recipes/catch2/conanfile.py
+++ b/recipes/catch2/conanfile.py
@@ -68,7 +68,7 @@ class Catch2Conan(ConanFile):
 
     def build_requirements(self):
         if Version(self.version) >= "3.8.0":
-            self.tool_requires("cmake/[>=3.16 <4]")
+            self.tool_requires("cmake/[>=4.3 <5]")
 
     def validate(self):
         check_min_cppstd(self, 14)

--- a/recipes/catch2/conanfile.py
+++ b/recipes/catch2/conanfile.py
@@ -16,7 +16,7 @@ required_conan_version = ">=2.4"
 
 class Catch2Conan(ConanFile):
     name = "catch2"
-    version = "3.14.0"
+    version = "3.15.0"
     description = (
         "A modern, C++-native, header-only, framework for unit-tests, TDD and BDD"
     )

--- a/recipes/catch2/conanfile.py
+++ b/recipes/catch2/conanfile.py
@@ -11,7 +11,7 @@ from conan.tools.scm import Version
 import os
 import textwrap
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2.5"
 
 
 class Catch2Conan(ConanFile):

--- a/recipes/gmp/conanfile.py
+++ b/recipes/gmp/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.microsoft import check_min_vs, is_msvc, unix_path
 import os
 import stat
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2.5"
 
 
 class GmpConan(ConanFile):

--- a/recipes/nanobind/conanfile.py
+++ b/recipes/nanobind/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy, rename
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2.5"
 
 
 class NanobindConan(ConanFile):

--- a/recipes/nanobind_json/conanfile.py
+++ b/recipes/nanobind_json/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2.5"
 
 
 class NanobindJsonConan(ConanFile):

--- a/recipes/rapidcheck/conanfile.py
+++ b/recipes/rapidcheck/conanfile.py
@@ -12,7 +12,7 @@ from conan.tools.scm import Version
 from os.path import join
 import textwrap
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2.5"
 
 
 class RapidcheckConan(ConanFile):

--- a/recipes/symengine/conanfile.py
+++ b/recipes/symengine/conanfile.py
@@ -19,7 +19,7 @@ from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2.5"
 
 
 class SymengineConan(ConanFile):

--- a/recipes/tsl-robin-map/conanfile.py
+++ b/recipes/tsl-robin-map/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=2.4"
+required_conan_version = ">=2.5"
 
 
 class TslRobinMapConan(ConanFile):


### PR DESCRIPTION
* Remove `macos-14` builds: this is about to be deprecated and we've already removed it from tket CI.
* Replace `windows-2025` with `windows-2025-vs2026` (which is about to become the new `windows-latest`). Will update tket to use this.
* Add boost 1.91.0 and catch2 3.15.0.
* Require newer cmake in catch2 recipe, to support Visual Studio 18 generator.
* Bump required conan version in all recipes in order to trigger rebuilds.