### PR TITLE
Restore windows-2022 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     needs: changed_recipes
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2025-vs2026']
+        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2022', 'windows-2025-vs2026']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set git to use LF

--- a/profiles/windows-2022
+++ b/profiles/windows-2022
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=msvc
+compiler.cppstd=14
+compiler.runtime=dynamic
+compiler.version=194
+os=Windows

--- a/recipes/boost/conanfile.py
+++ b/recipes/boost/conanfile.py
@@ -44,7 +44,7 @@ import shutil
 import sys
 import yaml
 
-required_conan_version = ">=2.5"
+required_conan_version = ">=2.6"
 
 # When adding (or removing) an option, also add this option to the list in
 # `rebuild-dependencies.yml` and re-run that script.

--- a/recipes/catch2/conanfile.py
+++ b/recipes/catch2/conanfile.py
@@ -11,7 +11,7 @@ from conan.tools.scm import Version
 import os
 import textwrap
 
-required_conan_version = ">=2.5"
+required_conan_version = ">=2.6"
 
 
 class Catch2Conan(ConanFile):

--- a/recipes/gmp/conanfile.py
+++ b/recipes/gmp/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.microsoft import check_min_vs, is_msvc, unix_path
 import os
 import stat
 
-required_conan_version = ">=2.5"
+required_conan_version = ">=2.6"
 
 
 class GmpConan(ConanFile):

--- a/recipes/nanobind/conanfile.py
+++ b/recipes/nanobind/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy, rename
 
-required_conan_version = ">=2.5"
+required_conan_version = ">=2.6"
 
 
 class NanobindConan(ConanFile):

--- a/recipes/nanobind_json/conanfile.py
+++ b/recipes/nanobind_json/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=2.5"
+required_conan_version = ">=2.6"
 
 
 class NanobindJsonConan(ConanFile):

--- a/recipes/rapidcheck/conanfile.py
+++ b/recipes/rapidcheck/conanfile.py
@@ -12,7 +12,7 @@ from conan.tools.scm import Version
 from os.path import join
 import textwrap
 
-required_conan_version = ">=2.5"
+required_conan_version = ">=2.6"
 
 
 class RapidcheckConan(ConanFile):

--- a/recipes/symengine/conanfile.py
+++ b/recipes/symengine/conanfile.py
@@ -19,7 +19,7 @@ from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=2.5"
+required_conan_version = ">=2.6"
 
 
 class SymengineConan(ConanFile):

--- a/recipes/tsl-robin-map/conanfile.py
+++ b/recipes/tsl-robin-map/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=2.5"
+required_conan_version = ">=2.6"
 
 
 class TslRobinMapConan(ConanFile):


### PR DESCRIPTION
Hopefully we can remove them soon, but it was a mistake to remove them before fully testing the tket workflow with windows-2025-vs2026: there is a puzzling failure in the pytket builds that I haven't understood. So for the short term we need this in order for the tket builds to work.